### PR TITLE
Add support for getting index state information

### DIFF
--- a/lib/neo4j/core/cypher_session/adaptors/bolt.rb
+++ b/lib/neo4j/core/cypher_session/adaptors/bolt.rb
@@ -66,7 +66,7 @@ module Neo4j
 
             result.map do |row|
               label, property = row.description.match(/INDEX ON :([^\(]+)\(([^\)]+)\)/)[1, 2]
-              {type: row.type.to_sym, label: label.to_sym, properties: [property.to_sym]}
+              {type: row.type.to_sym, label: label.to_sym, properties: [property.to_sym], state: row.state.to_sym}
             end
           end
 


### PR DESCRIPTION
The state information is already in the row object. This makes it accessible from the index query result object

Fixes #

This pull introduces/changes:
 * Adds the index state information to the index query result object. Allows operations like waiting for indices to come online prior to their use.




Pings:
@cheerfulstoic
@subvertallchris
